### PR TITLE
Introduce exception for unresolved bugs

### DIFF
--- a/bug_tracking.py
+++ b/bug_tracking.py
@@ -1,8 +1,18 @@
+class BugResolutionException(Exception):
+    """Exception for bugs not resolvable by this software"""
+    def __init__(self, name: str, description: str):
+        msg = self.format_message(name, description)
+        super().__init__(msg)
+
+    @staticmethod
+    def format_message(name, description):
+        return f"Sorry we cannot help you with {name}, please consult the physical bug tracking."
+
 def bug_tracking():
     print("Welcome to EmilyOS digital bug tracking")
     bug_title = input("Give your bug a title: \n")
     bug_description = input("Please describe your issue: \n")
-    print(f"Sorry we cannot help you with {bug_title}, please consult the physical bug tracking.")
+    raise BugResolutionException(bug_title, bug_description)
     
 
 


### PR DESCRIPTION
BugResolutionException is now returned when bug_tracking is unable to deal with a bug.
This makes bug_tracking much more extensible and easy to work with as other software can now use this function and only needs to handle exceptions instead of handling no return value.